### PR TITLE
Fix to preserve domain and ir_version. Also, API specification changes due to the version upgrade of onnx are now supported.

### DIFF
--- a/spo4onnx/__init__.py
+++ b/spo4onnx/__init__.py
@@ -1,3 +1,3 @@
 from spo4onnx.onnx_partial_optimization import partial_optimization, main
 
-__version__ = '1.0.3'
+__version__ = '1.0.4'


### PR DESCRIPTION
1. Fix to preserve `domain` and `ir_version`. 
2. API specification changes due to the version upgrade of onnx are now supported. `onnx==1.16.0`

